### PR TITLE
changes 30/08/2018

### DIFF
--- a/docsbox/__init__.py
+++ b/docsbox/__init__.py
@@ -1,5 +1,5 @@
 from flask import Flask
-from flask.ext.rq2 import RQ
+from flask_rq2 import RQ
 from flask_restful import Api
 from flask_env_settings import Settings
 
@@ -23,10 +23,14 @@ Settings(app, rules={
 api = Api(app)
 rq = RQ(app)
 
-from docsbox.docs.views import DocumentView, DocumentCreateView
+from docsbox.docs.views import *
     
-api.add_resource(DocumentView, "/api/v1/<task_id>")
-api.add_resource(DocumentCreateView, "/api/v1/")
+api.add_resource(DocumentStateView, "/api/document/<task_id>")
+api.add_resource(DocumentTypeView, "/api/document")
+api.add_resource(DocumentConvertView, "/api/document/convert")
+api.add_resource(DocumentUploadView, "/api/document/upload")
+api.add_resource(DocumentDownloadView, "/api/document/download/<task_id>")
+
 
 if __name__ == "__main__":
     app.run()

--- a/docsbox/docs/utils.py
+++ b/docsbox/docs/utils.py
@@ -3,6 +3,8 @@ import zipfile
 
 from wand.image import Image
 
+from magic import Magic
+
 from docsbox import app
 
 
@@ -11,19 +13,20 @@ def make_zip_archive(uuid, tmp_dir):
     Creates ZIP archive from given @tmp_dir.
     """
     zipname = "{0}.zip".format(uuid)
-    result_path = os.path.join(app.config["MEDIA_PATH"],
-                               zipname)
-    result_url = os.path.join(app.config["MEDIA_URL"],
-                              zipname)
+    result_path = os.path.join(app.config["MEDIA_PATH"], zipname)
+
     with zipfile.ZipFile(result_path, "w") as output:
         for dirname, subdirs, files in os.walk(tmp_dir):
             for filename in files:
                 path = os.path.join(dirname, filename)
                 output.write(path, path.split(tmp_dir)[1])
-    return result_path, result_url
+    return result_path, zipname
 
 
 def make_thumbnails(image, tmp_dir, size):
+    """ 
+    This method is not called while GENERATE_THUMBNAILS in settings.py is false
+    """
     thumbnails_folder = os.path.join(tmp_dir, "thumbnails/")
     os.mkdir(thumbnails_folder)
     (width, height) = size
@@ -32,9 +35,14 @@ def make_thumbnails(image, tmp_dir, size):
             filename = os.path.join(thumbnails_folder, "{0}.png".format(index))
             page.resize(width, height)
             if app.config["THUMBNAILS_QUANTIZE"]:
-                page.quantize(app.config["THUMBNAILS_QUANTIZE_COLORS"], 
+                page.quantize(app.config["THUMBNAILS_QUANTIZE_COLORS"],
                               app.config["THUMBNAILS_QUANTIZE_COLORSPACE"], 0, True, True)
             page.save(filename=filename)
     else:
         image.close()
     return index
+
+
+def get_file_mimetype(file):
+    with Magic() as magic:  # detect mimetype
+        return magic.from_file(file.name)

--- a/docsbox/docs/views.py
+++ b/docsbox/docs/views.py
@@ -1,17 +1,14 @@
 import ujson
 import datetime
 
-from magic import Magic
-from tempfile import NamedTemporaryFile
-
-from flask import request
+from flask import request, send_from_directory
 from flask_restful import Resource, abort
 
 from docsbox import app, rq
-from docsbox.docs.tasks import remove_file, process_document
+from docsbox.docs.tasks import process_document_convertion, upload_document, create_temp_file
+from docsbox.docs.utils import get_file_mimetype
 
-
-class DocumentView(Resource):
+class DocumentStateView(Resource):
 
     def get(self, task_id):
         """
@@ -22,48 +19,63 @@ class DocumentView(Resource):
         if task:
             return {
                 "id": task.id,
-                "status": task.status,
-                "result_url": task.result
+                "status": task.status
             }
         else:
             return abort(404, message="Unknown task_id")
 
 
-class DocumentCreateView(Resource):
+class DocumentTypeView(Resource):
 
-    def post(self):
+    def get(self):
         """
-        Recieves file and options, checks file mimetype,
-        validates options and creates converting task
+            Returns the File Type
         """
         if "file" not in request.files:
             return abort(400, message="file field is required")
         else:
-            with NamedTemporaryFile(delete=False, prefix=app.config["MEDIA_PATH"]) as tmp_file:
-                request.files["file"].save(tmp_file)
-                tmp_file.flush()
-                tmp_file.close()
-                remove_file.schedule(
-                    datetime.timedelta(seconds=app.config["ORIGINAL_FILE_TTL"])
-                , tmp_file.name)
-                with Magic() as magic: # detect mimetype
-                    mimetype = magic.from_file(tmp_file.name)
-                    if mimetype not in app.config["SUPPORTED_MIMETYPES"]:
-                        return abort(400, message="Not supported mimetype: '{0}'".format(mimetype))
+            tmp_file = create_temp_file(request.files["file"])
+            mimetype = get_file_mimetype(tmp_file)
+        return {
+                "mimetype": mimetype
+            }
+
+
+class DocumentConvertView(Resource):
+
+    def post(self):
+        """
+            Validates options and creates converting task
+        """
+        if "file" not in request.files:
+            return abort(400, message="file field is required")
+        else:
+            tmp_file = create_temp_file(request.files["file"])
+            mimetype = get_file_mimetype(tmp_file)
+            if mimetype in app.config["ACCEPTED_MIMETYPES"]:
+                return {
+                    "message": "File does not need to be converted."
+                }
+            else:
+                if mimetype not in app.config["CONVERTABLE_MIMETYPES"]:
+                    return abort(400, message="Not supported mimetype: '{0}'".format(mimetype))
+
                 options = request.form.get("options", None)
-                if options: # options validation
+                if options:  # options validation
                     options = ujson.loads(options)
                     formats = options.get("formats", None)
                     if not isinstance(formats, list) or not formats:
                         return abort(400, message="Invalid 'formats' value")
                     else:
                         for fmt in formats:
-                            supported = (fmt in app.config["SUPPORTED_MIMETYPES"][mimetype]["formats"])
+                            supported = (
+                                fmt in app.config["CONVERTABLE_MIMETYPES"][mimetype]["formats"])
                             if not supported:
                                 message = "'{0}' mimetype can't be converted to '{1}'"
                                 return abort(400, message=message.format(mimetype, fmt))
-                    thumbnails = options.get("thumbnails", None)
-                    if thumbnails:
+
+                    thumbnails = options.get("thumbnails", None) # check for thumbnails options on request and if they are valid
+                    if app.config["GENERATE_THUMBNAILS"] and thumbnails: # GENERATE_THUMBNAILS is configured as False
                         if not isinstance(thumbnails, dict):
                             return abort(400, message="Invalid 'thumbnails' value")
                         else:
@@ -72,22 +84,61 @@ class DocumentCreateView(Resource):
                                 return abort(400, message="Invalid 'size' value")
                             else:
                                 try:
-                                    (width, height) = map(int, thumbnails_size.split("x"))
+                                    (width, height) = map(
+                                        int, thumbnails_size.split("x"))
                                 except ValueError:
                                     return abort(400, message="Invalid 'size' value")
                                 else:
                                     options["thumbnails"]["size"] = (width, height)
+
                 else:
-                    if mimetype == "application/pdf":
-                        options = {
-                            "formats": ["html"]
-                        }
-                    else:
-                        options = app.config["DEFAULT_OPTIONS"]
-                task = process_document.queue(tmp_file.name, options, {
-                    "mimetype": mimetype,
-                })
+                    options = app.config["DEFAULT_OPTIONS"]
+            task = process_document_convertion.queue(tmp_file.name, options, {
+                "mimetype": mimetype,
+            })
         return {
             "id": task.id,
             "status": task.status,
         }
+
+
+class DocumentUploadView(Resource):
+
+    def post(self):
+        """
+            Recieves file, checks file mimetype and saves original document
+        """
+        if "file" not in request.files:
+            return abort(400, message="file field is required")
+        else:
+            tmp_file = create_temp_file(request.files["file"])
+            mimetype = get_file_mimetype(tmp_file)
+            if mimetype not in app.config["ACCEPTED_MIMETYPES"]:
+                if mimetype not in app.config["CONVERTABLE_MIMETYPES"]:
+                    return abort(400, message="Not supported mimetype: '{0}'".format(mimetype))
+                return {
+                    "message": "File cannot be uploaded needs to be converted"
+                }
+                
+            task = upload_document.queue(tmp_file.name, app.config["ACCEPTED_MIMETYPES"][mimetype]["format"])
+        return {
+            "id": task.id,
+            "status": task.status
+        }
+
+
+class DocumentDownloadView(Resource):
+
+    def get(self, task_id):
+        """
+            Returns the Converted File
+        """
+        queue = rq.get_queue()
+        task = queue.fetch_job(task_id)
+        if task:
+            if task.status == "finished":
+                return send_from_directory(app.config["MEDIA_PATH"], task.result, as_attachment=True)
+            else:
+                return abort(400, message="Task is still queued")
+        else:
+            return abort(404, message="Unknown task_id")

--- a/docsbox/settings.py
+++ b/docsbox/settings.py
@@ -7,31 +7,84 @@ BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 MEDIA_PATH = os.path.join(BASE_DIR, "media/")
 MEDIA_URL = "/media/"
 
-SUPPORTED_FORMATS = { 
-    "pdf": {
-        "path": "pdf",
-        "fmt": "pdf",
+SUPPORTED_FORMATS = { "pdf", "txt", "csv", "jpeg", "png" }
+
+GENERATE_THUMBNAILS = False # If True enables the option of thumbnails generation
+
+DOCUMENT_EXPORT_FORMATS = ["pdf", "txt"]
+SPREADSHEET_EXPORT_FORMATS = ["pdf", "csv"]
+PRESENTATION_EXPORT_FORMATS = ["pdf"]
+IMAGE_EXPORT_FORMATS = ["jpeg", "png"]
+PDF_EXPORT_FORMATS = ["pdf"]
+
+ACCEPTED_MIMETYPES = {
+    # LibreOffice Writer
+    "application/vnd.oasis.opendocument.text": {
+        "format": "odt",
     },
-    "txt": {
-        "path": "txt",
-        "fmt": "txt",
+
+    # LibreOffice Calc
+    "application/vnd.oasis.opendocument.spreadsheet": {
+        "format": "ods",
     },
-    "html": {
-        "path": "html",
-        "fmt": "html",
+
+    # LibreOffice Impress
+    "application/vnd.oasis.opendocument.presentation": {
+        "format": "odp",
     },
-    "csv": {
-        "path": "csv",
-        "fmt": "csv",
-    }
+
+    # LibreOffice Draw
+    "application/vnd.oasis.opendocument.graphics": {
+        "format": "odg",
+    },
+
+    # LibreOffice Math
+    "application/vnd.oasis.opendocument.formula": {
+        "format": "odf",
+    },
+
+    # Comma Seperated Values
+    "text/plain": {
+        "format": "txt",
+    },
+
+    # Comma Seperated Values
+    "text/scv": {
+        "format": "csv",
+    },
+
+    # Portable Document Format
+    "application/pdf": {
+        "format": "pdf",
+    },
+
+    # EPUB
+    "application/epub+zip": {
+        "format": "epub",
+    },
+
+    # Free Lossless Audio Codec
+    "audio/flac": {
+        "format": "flac"
+    },
+
+    # Advanced Video Coding
+    "video/mp4": {
+        "format": "mp4"
+    },
+
+    # Joint Photographic Group
+    "image/jpeg": {
+        "format": "jpeg"
+    },
+
+    # Portable Network Graphics
+    "image/png": {
+        "format": "png"
+    },
 }
 
-DOCUMENT_EXPORT_FORMATS = ["pdf", "txt", "html"]
-SPREADSHEET_EXPORT_FORMATS = ["pdf", "csv", "html"]
-PRESENTATION_EXPORT_FORMATS = ["pdf", "html"]
-PDF_EXPORT_FORMATS = ["html"]
-
-SUPPORTED_MIMETYPES = {
+CONVERTABLE_MIMETYPES = {
     # Microsoft Word 2003
     "application/msword": {
         "formats": DOCUMENT_EXPORT_FORMATS,
@@ -39,21 +92,6 @@ SUPPORTED_MIMETYPES = {
     
     # Microsoft Word 2007
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document": {
-        "formats": DOCUMENT_EXPORT_FORMATS,
-    },
-    
-    # LibreOffice Writer
-    "application/vnd.oasis.opendocument.text": {
-        "formats": DOCUMENT_EXPORT_FORMATS,
-    },
-
-    # Portable Document Format
-    "application/pdf": {
-        "formats": PDF_EXPORT_FORMATS,
-    },
-
-    # Rich Text Format
-    "text/rtf": {
         "formats": DOCUMENT_EXPORT_FORMATS,
     },
 
@@ -67,11 +105,6 @@ SUPPORTED_MIMETYPES = {
         "formats": SPREADSHEET_EXPORT_FORMATS,
     },
 
-    # LibreOffice Calc
-    "application/vnd.oasis.opendocument.spreadsheet": {
-        "formats": SPREADSHEET_EXPORT_FORMATS,
-    },
-
     # Microsoft Powerpoint 2003
     "application/vnd.ms-powerpoint": {
         "formats": PRESENTATION_EXPORT_FORMATS,
@@ -82,9 +115,55 @@ SUPPORTED_MIMETYPES = {
         "formats": PRESENTATION_EXPORT_FORMATS,
     },
 
-    # LibreOffice Impress
-    "application/vnd.oasis.opendocument.presentation": {
+    # Rich Text Format
+    "text/rtf": {
+        "formats": DOCUMENT_EXPORT_FORMATS,
+    },
+
+    #XML OpenOffice
+    # sxw
+    "application/vnd.sun.xml.writer": {
+        "formats": DOCUMENT_EXPORT_FORMATS,
+    },
+
+    # sxc
+    "application/vnd.sun.xml.calc": {
+        "formats": SPREADSHEET_EXPORT_FORMATS,
+    },
+
+    # sxd
+    "application/vnd.sun.xml.draw": {
         "formats": PRESENTATION_EXPORT_FORMATS,
+    },
+
+    # sxi
+    "application/vnd.sun.xml.impress": {
+        "formats": PRESENTATION_EXPORT_FORMATS,
+    },
+
+    # sxm
+    "application/vnd.sun.xml.math": {
+        "formats": SPREADSHEET_EXPORT_FORMATS,
+    },
+
+    # sxg
+    "application/vnd.sun.xml.writer.global": {
+        "formats": DOCUMENT_EXPORT_FORMATS,
+    },
+
+    #Apple Keynote
+    "application/vnd.apple.keynote":{
+        "formats": PRESENTATION_EXPORT_FORMATS,
+    },
+
+    #Apple Numbers
+    "application/vnd.apple.numbers":{
+        "formats": SPREADSHEET_EXPORT_FORMATS,
+    },
+
+    #Apple Pages
+    "application/vnd.apple.pages":{
+        "formats": DOCUMENT_EXPORT_FORMATS,
     },
 }
 


### PR DESCRIPTION
Changes done till 30/08/2018

- Thumbnails are currently disabled, can be enabled in setings.py.
- Upload and conversion are separated, messages are returned if file type needs to be converted or if can be uploaded without need of conversion (all of this can still be changed in settings.py).
- There is a new request for checking a file type.
- Checking the a task only returns the status and id, there is no return_url (if needed return may give the converted file name + extension).
- New request to download file, needs task id, returns file not a zip
- README.md was also updated with the new examples of request.