### PR TITLE
SAM-368 conversion for open office documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ $ curl -X GET http://localhost/conversion-service/get-converted-file/bbf78afd-01
     "fileType": "PDF/A",
     "status": "finished",
     "taskId": "bbf78afd-011c-4815-95da-17b810fa4f5f"
+    "fileSize": "80325"
 }
 ```
 ```bash
@@ -170,9 +171,9 @@ Tests can be run with VIA or without, if connection to VIA is not possible, TEST
 ```
 
 # Supported filetypes
-| Type           | Format                                     | 
-| ---------------|------------------------------------------- |
-| Document       | `.docx` `.doc` `.kth` `.rtf` `.pdf` `.sxw` |
-| Presentation   | `.pptx` `.ppt` `.pages` `.sxi`             |
-| Spreadsheet    | `.xlsx` `.xls` `.numbers` `.sxc`           |
-| Others         | `.sxd` `.sxg`
+| Type           | Format                                            | 
+| ---------------|-------------------------------------------------- |
+| Document       | `.docx` `.doc` `.kth` `.rtf` `.pdf` `.sxw` `.odt` |
+| Presentation   | `.pptx` `.ppt` `.pages` `.sxi` `.odp`             |
+| Spreadsheet    | `.xlsx` `.xls` `.numbers` `.sxc` `.ods`           |
+| Others         | `.sxd` `.sxg` `.odg`                              |

--- a/docsbox/config/config.yml
+++ b/docsbox/config/config.yml
@@ -29,41 +29,6 @@ COMMON: &common
 
   DOCUMENT_CONVERTION_FORMATS: ["DOCUMENT_EXPORT_FORMATS", "SPREADSHEET_EXPORT_FORMATS", "PRESENTATION_EXPORT_FORMATS", "PDF_EXPORT_FORMATS"]
 
-  ACCEPTED_MIMETYPES:
-    application/vnd.oasis.opendocument.text: # LibreOffice Word
-      name: "OpenDocument Text"
-      format: "odt"
-    application/vnd.oasis.opendocument.spreadsheet: # LibreOffice Calc
-      name: "OpenDocument SpreadSheet"
-      format: "ods"
-    application/vnd.oasis.opendocument.presentation: # LibreOffice Impress
-      name: "OpenDocument Presentation"
-      format: "odp"
-    application/vnd.oasis.opendocument.graphics: # LibreOffice Draw
-      name: "OpenDocument Graphics"
-      format: "odg"
-    application/vnd.oasis.opendocument.formula: # LibreOffice Math
-      name: "OpenDocument Formula"
-      format: "odf"
-    text/plain: # Plain Text File
-      name: "Text"
-      format: "txt"
-    text/csv: # Comma Seperated Values
-      name: "CSV"
-      format: "csv"
-    application/pdfa: # Portable Document Format Archive
-      name: "PDF/A"
-      format: "pdf"
-    application/epub+zip: # EPUB
-      name: "ePUB"
-      format: "epub"
-    audio/x-flac: # Free Lossless Audio Codec
-      name: "Flac"
-      format: "flac"
-    video/mp4: # Advanced Video Coding
-      name: "MP4"
-      format: "mp4"
-
   CONVERTABLE_MIMETYPES:
     application/pdf: # Portable Document Format
       name: "PDF"
@@ -137,6 +102,27 @@ COMMON: &common
       name: "PNG"
       formats: DOCUMENT_EXPORT_FORMATS
       default_options: DEFAULT_OPTIONS
+    application/vnd.oasis.opendocument.text: # LibreOffice Word
+      name: "OpenDocument Text"
+      formats: DOCUMENT_EXPORT_FORMATS
+      default_options: DEFAULT_OPTIONS
+    application/vnd.oasis.opendocument.spreadsheet: # LibreOffice Calc
+      name: "OpenDocument SpreadSheet"
+      formats: "SPREADSHEET_EXPORT_FORMATS"
+      default_options: DEFAULT_OPTIONS
+    application/vnd.oasis.opendocument.presentation: # LibreOffice Impress
+      name: "OpenDocument Presentation"
+      formats: "PRESENTATION_EXPORT_FORMATS"
+      default_options: DEFAULT_OPTIONS
+    application/vnd.oasis.opendocument.graphics: # LibreOffice Draw
+      name: "OpenDocument Graphics"
+      formats: "PRESENTATION_EXPORT_FORMATS"
+      default_options: DEFAULT_OPTIONS
+
+  OUTPUT_FILETYPES:
+    application/pdfa:
+      name: "PDF/A"
+      format: "pdf"
 
   DEFAULT_OPTIONS:
     format: "pdf"

--- a/docsbox/docs/tasks.py
+++ b/docsbox/docs/tasks.py
@@ -73,15 +73,12 @@ def process_document_convertion(path, options, meta, current_task):
             if options["format"] in app.config[app.config["CONVERTABLE_MIMETYPES"][meta["mimetype"]]["formats"]]:
                 file_name = "{0}.{1}".format(meta["filename"], options["format"])
                 original_document.saveAs(output_path, fmt=options["format"], options="SelectPdfVersion=1")
-                # We checks the config for the mimetype of the converted format, expect if its pdf
-                # Because in the config pdf format is as application/pdfa to diferenciate versions
-                if options["format"] == "pdf":
-                    mimetype ="application/pdf"
-                    filetype="PDF/A"
-                else:
-                    mimetype = (key for key, value in app.config["ACCEPTED_MIMETYPES"].items() if value["format"] == options["format"])
-                    filetype = app.config["ACCEPTED_MIMETYPES"][mimetype]["name"]
-                    
+                
+                for key, value in app.config["OUTPUT_FILETYPES"].items():
+                    if value["format"] == options["format"]:
+                        mimetype = key
+                        filetype = value["name"]
+
                 if app.config["THUMBNAILS_GENERATE"] and options.get("thumbnails", None): # generate thumbnails
                         output_path, file_name = thumbnail_generator(path, options, meta, current_task, original_document) 
     fileSize = os.path.getsize(output_path)

--- a/docsbox/docs/tests/test_dependencies.py
+++ b/docsbox/docs/tests/test_dependencies.py
@@ -1,13 +1,5 @@
 filesNotConvertable = [
     {
-     "fileExt": ".ODT",
-     "fileName": "test6",
-     "fileNameExt": "test6.odt",
-     "mimeType": "application/vnd.oasis.opendocument.text",
-     "fileType": "OpenDocument Text",
-     "fileId": "2ca6808c-941c-4e7e-978d-5d9f88dfdd4f"
-    },
-    {
     "fileExt": ".PDF-A",
     "fileName": "test36",
     "fileNameExt": "test36.pdf",
@@ -16,76 +8,52 @@ filesNotConvertable = [
     "fileId": "a5c9416d-b044-4dff-9cf9-983ad592a3ba"
     },
     {
-    "fileExt": ".ODP",
-    "fileName": "test4",
-    "fileNameExt": "test4.odp",
-    "mimeType": "application/vnd.oasis.opendocument.presentation",
-    "fileType": "OpenDocument Presentation",
-    "fileId": "9b4e4fe5-abd8-41e7-a6dd-e081271f6ed9"
-    },
-    {
-    "fileExt": ".ODG",
-    "fileName": "test18",
-    "fileNameExt": "test18.odg",
-    "mimeType": "application/vnd.oasis.opendocument.graphics",
-    "fileType": "OpenDocument Graphics",
-    "fileId": "eed6ee00-305d-4488-9556-00bcc04fb3d0"
-    },
-    {
-    "fileExt": ".ODF",
-    "fileName": "test19",
-    "fileNameExt": "test19.odf",
-    "mimeType": "application/vnd.oasis.opendocument.formula",
-    "fileType": "OpenDocument Formula",
-    "fileId": "7dd765b6-bc52-42dd-8531-3c5cc9a1911d"
-    },
-    {
-    "fileExt": ".ODS",
-    "fileName": "test20",
-    "fileNameExt": "test20.ods",
-    "mimeType": "application/vnd.oasis.opendocument.spreadsheet",
-    "fileType": "OpenDocument SpreadSheet",
-    "fileId": "76abc065-9d46-46b2-85a8-d3596d574d9a"
-    },
-    {
-    "fileExt": ".TXT",
-    "fileName": "test11",
-    "fileNameExt": "test11.txt",
-    "mimeType": "text/plain",
-    "fileType": "Text",
-    "fileId": "3c58bc77-e40f-40f9-b5b2-710c652eac89"
-    },
-    {
-    "fileExt": ".EPUB",
-    "fileName": "test14",
-    "fileNameExt": "test14.epub",
-    "mimeType": "application/epub+zip",
-    "fileType": "ePUB",
-    "fileId": "9106d286-a47a-474a-a472-3e34e01469e6"
-    },
-    {
     "fileExt": ".MP4",
     "fileName": "test15",
     "fileNameExt": "test15.mp4",
     "mimeType": "video/mp4",
-    "fileType": "MP4",
+    "fileType": "video/mp4",
     "fileId": "6cd2f270-7821-43ee-b807-fa97d0cb77cc"
-    },
-    {
-    "fileExt": ".CSV",
-    "fileName": "test12",
-    "fileNameExt": "test12.csv",
-    "mimeType": "text/csv",
-    "fileType": "CSV",
-    "fileId": "af94093a-bb29-4b86-9605-2f16dd76ed80"
     },
     {
     "fileExt": ".FLAC",
     "fileName": "test16",
     "fileNameExt": "test16.flac",
     "mimeType": "audio/x-flac",
-    "fileType": "Flac",
+    "fileType": "audio/x-flac",
     "fileId": "d735d56e-e854-4c21-a1fd-5e092016c859"
+    },
+    {
+    "fileExt": ".EPUB",
+    "fileName": "test14",
+    "fileNameExt": "test14.epub",
+    "mimeType": "application/epub+zip",
+    "fileType": "application/epub+zip",
+    "fileId": "9106d286-a47a-474a-a472-3e34e01469e6"
+    },
+    {
+    "fileExt": ".PYTHON",
+    "fileName": "test35",
+    "fileNameExt": "test35.py",
+    "mimeType": "text/x-python",
+    "fileType": "text/x-python",
+    "fileId": "2d431c06-6cfe-4f16-ba8d-51c58da502e5"
+    },
+    {
+    "fileExt": ".TXT",
+    "fileName": "test11",
+    "fileNameExt": "test11.txt",
+    "mimeType": "text/plain",
+    "fileType": "text/plain",
+    "fileId": "3c58bc77-e40f-40f9-b5b2-710c652eac89"
+    },
+    {
+    "fileExt": ".CSV",
+    "fileName": "test12",
+    "fileNameExt": "test12.csv",
+    "mimeType": "text/csv",
+    "fileType": "text/csv",
+    "fileId": "af94093a-bb29-4b86-9605-2f16dd76ed80"
     }
 ]
 
@@ -233,6 +201,46 @@ filesConvertable = [
     "mimeType":  "image/png",
     "fileType": "PNG",
     "fileId": "a8cd8a1e-ec68-4ede-821b-4c8df4944cee"
+    },
+    {
+     "fileExt": ".ODT",
+     "fileName": "test6",
+     "fileNameExt": "test6.odt",
+     "mimeType": "application/vnd.oasis.opendocument.text",
+     "fileType": "OpenDocument Text",
+     "fileId": "2ca6808c-941c-4e7e-978d-5d9f88dfdd4f"
+    },
+    {
+    "fileExt": ".ODP",
+    "fileName": "test4",
+    "fileNameExt": "test4.odp",
+    "mimeType": "application/vnd.oasis.opendocument.presentation",
+    "fileType": "OpenDocument Presentation",
+    "fileId": "9b4e4fe5-abd8-41e7-a6dd-e081271f6ed9"
+    },
+    {
+    "fileExt": ".ODG",
+    "fileName": "test18",
+    "fileNameExt": "test18.odg",
+    "mimeType": "application/vnd.oasis.opendocument.graphics",
+    "fileType": "OpenDocument Graphics",
+    "fileId": "eed6ee00-305d-4488-9556-00bcc04fb3d0"
+    },
+    # {
+    # "fileExt": ".ODF",
+    # "fileName": "test19",
+    # "fileNameExt": "test19.odf",
+    # "mimeType": "application/vnd.oasis.opendocument.formula",
+    # "fileType": "OpenDocument Formula",
+    # "fileId": "7dd765b6-bc52-42dd-8531-3c5cc9a1911d"
+    # },
+    {
+    "fileExt": ".ODS",
+    "fileName": "test20",
+    "fileNameExt": "test20.ods",
+    "mimeType": "application/vnd.oasis.opendocument.spreadsheet",
+    "fileType": "OpenDocument SpreadSheet",
+    "fileId": "76abc065-9d46-46b2-85a8-d3596d574d9a"
     }
     # DISCARD SUPPORT TO (.SXM, .STD, .STW, .STC, .STI)
     # {
@@ -265,15 +273,4 @@ filesConvertable = [
     # "mimeType": "application/vnd.sun.xml.impress.template",
     # "fileId": ""
     # }
-]
-
-filesUnknown = [
-    {
-    "fileExt": ".PYTHON",
-    "fileName": "test35",
-    "fileNameExt": "test35.py",
-    "mimeType": "text/x-python",
-    "fileType": "Unknown",
-    "fileId": "2d431c06-6cfe-4f16-ba8d-51c58da502e5"
-    }
 ]

--- a/docsbox/docs/tests/test_views.py
+++ b/docsbox/docs/tests/test_views.py
@@ -127,17 +127,7 @@ class DocumentDeleteTemporaryFilesTestCase(BaseTestCase):
      
 # Group of tests to test detection of type file and check if it's possible to convert
 class DocumentDetectAndConvertTestCase(BaseTestCase):   
-    def test_convert_invalid_mimetype(self):
-        if self.via_run == "True":
-            response = self.convert_file_VIA(dep.filesUnknown[0]['fileId'], dep.filesUnknown[0]['fileName']) 
-        else:
-            response = self.convert_file_nVIA(dep.filesUnknown[0]['fileNameExt']) 
-        json = ujson.loads(response.data)
-        self.assertEqual(response.status_code, 415)
-        self.assertEqual(json, {
-            "message": "Not supported mimetype: '"+dep.filesUnknown[0]['mimeType']+"'"
-        })
-    
+
     def test_convert_empty_formats(self):
         if self.via_run == "True":
             response = self.convert_file_with_options_VIA(dep.filesConvertable[0]['fileId'], dep.filesConvertable[0]['fileName'], {
@@ -168,7 +158,7 @@ class DocumentDetectAndConvertTestCase(BaseTestCase):
             "message": "'application/vnd.sun.xml.writer' mimetype can't be converted to 'csv'"
         })
 
-    def test_detect_convert_file_not_required(self):
+    def test_detect_convert_file_not_convertable(self):
         for file in dep.filesNotConvertable:
             # Detect file type   
             if self.via_run == "True":
@@ -188,12 +178,12 @@ class DocumentDetectAndConvertTestCase(BaseTestCase):
             else:
                 response = self.convert_file_nVIA(file['fileNameExt']) 
             json = ujson.loads(response.data)
-            self.assertEqual(response.status_code, 400)
+            self.assertEqual(response.status_code, 415)
             self.assertEqual(json, {
-                'message': 'File does not need to be converted.'
+                'message': "Not supported mimetype: '{0}'".format(file['mimeType'])
             })
         
-    def test_detect_convert_file_required(self):
+    def test_detect_convert_file(self):
         for file in dep.filesConvertable:            
             # Detect file type   
             if self.via_run == "True":
@@ -233,7 +223,7 @@ class DocumentDetectAndConvertTestCase(BaseTestCase):
 # Test to tests all process, detect, convert and retrieve file for output folder
 class DocumentDetectConvertAndRetrieveTestCase(BaseTestCase):
     def test_detect_convert_retrieve_file(self):
-        mergeLists = dep.filesConvertable + dep.filesNotConvertable + dep.filesUnknown
+        mergeLists = dep.filesConvertable + dep.filesNotConvertable
         for file in mergeLists:       
             # Detect file type   
             if self.via_run == "True":

--- a/docsbox/docs/views.py
+++ b/docsbox/docs/views.py
@@ -64,11 +64,11 @@ class DocumentTypeView(Resource):
         else:
             abort(400, "No file has sent nor valid file_id given.", request)
 
-        isConvertable = mimetype not in app.config["ACCEPTED_MIMETYPES"] and mimetype in app.config["CONVERTABLE_MIMETYPES"]
+        isConvertable = mimetype in app.config["CONVERTABLE_MIMETYPES"]
         if isConvertable:
             filetype = app.config["CONVERTABLE_MIMETYPES"][mimetype]["name"]
         else:
-            filetype = app.config["ACCEPTED_MIMETYPES"][mimetype]["name"] if mimetype in app.config["ACCEPTED_MIMETYPES"] else "Unknown"
+            filetype = app.config["OUTPUT_FILETYPES"][mimetype]["name"] if mimetype in app.config["OUTPUT_FILETYPES"] else mimetype
         response= { "convertable": isConvertable, "fileType": filetype }
         app.logger.log(logging.INFO, response, extra={"request": request, "status": 200})
         return response
@@ -107,9 +107,6 @@ class DocumentConvertView(Resource):
 
         mimetype = result['mimetype']
         tmp_file = result['tmp_file']
-        
-        if mimetype in app.config["ACCEPTED_MIMETYPES"]:
-            abort(400, "File does not need to be converted.", request)
             
         if mimetype not in app.config["CONVERTABLE_MIMETYPES"]:
             abort(415, "Not supported mimetype: '{0}'".format(mimetype), request)


### PR DESCRIPTION
- Removed Accepted files list
- Added OpenOffice Documents to the Convertible Files list
- Created Output File list
- In get-file-type request if file is not in the Convertible Files list, checks if its in Output File list else returns the mimetype, does not return "Unknown" anymore.
- Updated readme file
- Updated automated tests