### PR TITLE
Hide PDF metadata and improved accessibility

### DIFF
--- a/docsbox/config/registrymodifications.xcu
+++ b/docsbox/config/registrymodifications.xcu
@@ -1,12 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <oor:items xmlns:oor="http://openoffice.org/2001/registry" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<item oor:path="/org.openoffice.Office.Common/Accessibility"><prop oor:name="AutoDetectSystemHC" oor:op="fuse"><value>false</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/Accessibility"><prop oor:name="IsAllowAnimatedGraphics" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/Accessibility"><prop oor:name="IsAllowAnimatedText" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/Accessibility"><prop oor:name="IsAutomaticFontColor" oor:op="fuse"><value>false</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/Accessibility"><prop oor:name="IsForPagePreviews" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/Accessibility"><prop oor:name="IsSelectionInReadonly" oor:op="fuse"><value>false</value></prop></item>
 <item oor:path="/org.openoffice.Office.Common/Filter/PDF/Export"><prop oor:name="FormsType" oor:op="fuse"><value>1</value></prop></item>
 <item oor:path="/org.openoffice.Office.Common/Filter/PDF/Export"><prop oor:name="MaxImageResolution" oor:op="fuse"><value>150</value></prop></item>
-<item oor:path="/org.openoffice.Office.Common/Filter/PDF/Export"><prop oor:name="SelectPdfVersion" oor:op="fuse"><value>2</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/Filter/PDF/Export"><prop oor:name="SelectPdfVersion" oor:op="fuse"><value>1</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/Filter/PDF/Export"><prop oor:name="UseTaggedPDF" oor:op="fuse"><value>true</value></prop></item>
 <item oor:path="/org.openoffice.Office.Common/Misc"><prop oor:name="FirstRun" oor:op="fuse"><value>false</value></prop></item>
 <item oor:path="/org.openoffice.Office.Common/Misc"><prop oor:name="Persona" oor:op="fuse"><value>no</value></prop></item>
 <item oor:path="/org.openoffice.Office.Common/Misc"><prop oor:name="PersonaSettings" oor:op="fuse"><value></value></prop></item>
 <item oor:path="/org.openoffice.Office.Common/Misc"><prop oor:name="UseOpenCL" oor:op="fuse"><value>false</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/Load"><prop oor:name="UserDefinedSettings" oor:op="fuse"><value>false</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/Save/Document"><prop oor:name="CreateBackup" oor:op="fuse"><value>false</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/Save/Document"><prop oor:name="EditProperty" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/Save/Document"><prop oor:name="LoadPrinter" oor:op="fuse"><value>false</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/Save/Document"><prop oor:name="PrettyPrinting" oor:op="fuse"><value>false</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/Save/Document"><prop oor:name="UseUserData" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/Save/Document"><prop oor:name="ViewInfo" oor:op="fuse"><value>false</value></prop></item>
 <item oor:path="/org.openoffice.Office.Linguistic/ServiceManager/HyphenatorList"><prop oor:name="de-AT" oor:op="fuse" oor:type="oor:string-list"><value><it>org.openoffice.lingu.LibHnjHyphenator</it></value></prop></item>
 <item oor:path="/org.openoffice.Office.Linguistic/ServiceManager/HyphenatorList"><prop oor:name="de-BE" oor:op="fuse" oor:type="oor:string-list"><value><it>org.openoffice.lingu.LibHnjHyphenator</it></value></prop></item>
 <item oor:path="/org.openoffice.Office.Linguistic/ServiceManager/HyphenatorList"><prop oor:name="de-CH" oor:op="fuse" oor:type="oor:string-list"><value><it>org.openoffice.lingu.LibHnjHyphenator</it></value></prop></item>
@@ -96,4 +110,22 @@
 <item oor:path="/org.openoffice.Setup/Office"><prop oor:name="OfficeRestartInProgress" oor:op="fuse"><value>true</value></prop></item>
 <item oor:path="/org.openoffice.Setup/Office"><prop oor:name="ooSetupInstCompleted" oor:op="fuse"><value>true</value></prop></item>
 <item oor:path="/org.openoffice.Setup/Product"><prop oor:name="LastTimeGetInvolvedShown" oor:op="fuse"><value>0</value></prop></item>
+<item oor:path="/org.openoffice.UserProfile/Data"><prop oor:name="c" oor:op="fuse"><value></value></prop></item>
+<item oor:path="/org.openoffice.UserProfile/Data"><prop oor:name="encryptionkey" oor:op="fuse"><value></value></prop></item>
+<item oor:path="/org.openoffice.UserProfile/Data"><prop oor:name="encrypttoself" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.UserProfile/Data"><prop oor:name="facsimiletelephonenumber" oor:op="fuse"><value></value></prop></item>
+<item oor:path="/org.openoffice.UserProfile/Data"><prop oor:name="givenname" oor:op="fuse"><value></value></prop></item>
+<item oor:path="/org.openoffice.UserProfile/Data"><prop oor:name="homephone" oor:op="fuse"><value></value></prop></item>
+<item oor:path="/org.openoffice.UserProfile/Data"><prop oor:name="initials" oor:op="fuse"><value></value></prop></item>
+<item oor:path="/org.openoffice.UserProfile/Data"><prop oor:name="l" oor:op="fuse"><value></value></prop></item>
+<item oor:path="/org.openoffice.UserProfile/Data"><prop oor:name="mail" oor:op="fuse"><value></value></prop></item>
+<item oor:path="/org.openoffice.UserProfile/Data"><prop oor:name="o" oor:op="fuse"><value></value></prop></item>
+<item oor:path="/org.openoffice.UserProfile/Data"><prop oor:name="position" oor:op="fuse"><value></value></prop></item>
+<item oor:path="/org.openoffice.UserProfile/Data"><prop oor:name="postalcode" oor:op="fuse"><value></value></prop></item>
+<item oor:path="/org.openoffice.UserProfile/Data"><prop oor:name="signingkey" oor:op="fuse"><value></value></prop></item>
+<item oor:path="/org.openoffice.UserProfile/Data"><prop oor:name="sn" oor:op="fuse"><value></value></prop></item>
+<item oor:path="/org.openoffice.UserProfile/Data"><prop oor:name="st" oor:op="fuse"><value></value></prop></item>
+<item oor:path="/org.openoffice.UserProfile/Data"><prop oor:name="street" oor:op="fuse"><value></value></prop></item>
+<item oor:path="/org.openoffice.UserProfile/Data"><prop oor:name="telephonenumber" oor:op="fuse"><value></value></prop></item>
+<item oor:path="/org.openoffice.UserProfile/Data"><prop oor:name="title" oor:op="fuse"><value></value></prop></item>
 </oor:items>

--- a/docsbox/docs/tasks.py
+++ b/docsbox/docs/tasks.py
@@ -2,13 +2,14 @@ import os
 import datetime
 import subprocess
 
+from shutil import copyfile
 from pylokit import Office
 from wand.image import Image
 from img2pdf import convert as imagesToPdf
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from rq import get_current_job
 from docsbox import app, rq
-from docsbox.docs.utils import make_zip_archive, make_thumbnails, get_file_mimetype
+from docsbox.docs.utils import make_zip_archive, make_thumbnails, get_file_mimetype, copy_and_remove_metadata, remove_XMPMeta
 from docsbox.docs.via_controller import save_file_on_via
 
 
@@ -60,16 +61,20 @@ def process_convertion(path, options, meta):
 
 def process_document_convertion(path, options, meta, current_task):
     output_path = os.path.join(app.config["MEDIA_PATH"], current_task.id)
-    if (meta["mimetype"] == 'application/pdf'):
-        os.system('ocrmypdf --tesseract-timeout=0 --optimize 0 --skip-text {0} {1}'.format(path, output_path))
-    else:
+    if (meta["mimetype"] != 'application/pdf'):
         with Office(app.config["LIBREOFFICE_PATH"]) as office:  # acquire libreoffice lock
             with office.documentLoad(path) as original_document:  # open original document
                 if options["format"] in app.config[app.config["CONVERTABLE_MIMETYPES"][meta["mimetype"]]["formats"]]:
-                    original_document.saveAs(output_path, fmt=options["format"], options="SelectPdfVersion=2")
+                    original_document.saveAs(output_path, fmt=options["format"])
 
                     if app.config["THUMBNAILS_GENERATE"] and options.get("thumbnails", None): # generate thumbnails
                             output_path, file_name = thumbnail_generator(path, options, meta, current_task, original_document)
+    else:
+        copyfile(path, output_path)
+
+    copy_and_remove_metadata(output_path, path) #Remove all metadata from the files (Author, Title, etc)
+    os.system('ocrmypdf --tesseract-timeout=0 --optimize 0 --skip-text {0} {1}'.format(path, output_path))
+    remove_XMPMeta(output_path) #Removes XMP Metadata
 
     for key, value in app.config["OUTPUT_FILETYPES"].items():
         if value["format"] == options["format"]:

--- a/docsbox/docs/utils.py
+++ b/docsbox/docs/utils.py
@@ -5,7 +5,8 @@ import itertools
 import magic
 import re
 
-from PyPDF2 import PdfFileReader, xmp
+from PyPDF2 import PdfFileReader, PdfFileMerger, xmp
+from libxmp import XMPFiles, consts
 from wand.image import Image
 from docsbox import app
 
@@ -113,3 +114,20 @@ def remove_extension(file):
 
 def is_valid_uuid(uuid):
     return bool(re.match(r"([0-f]{8}-[0-f]{4}-[0-f]{4}-[0-f]{4}-[0-f]{12})", uuid))
+
+def copy_and_remove_metadata(file, new_file):
+    with open(file, mode="rb") as file_in:
+        pdf_merger = PdfFileMerger()
+        pdf_merger.append(file_in)
+        with open(new_file, mode="wb") as file_out:
+            pdf_merger.write(file_out)
+
+def remove_XMPMeta(file):
+    xmpfile = XMPFiles( file_path=file, open_forupdate=True )
+    xmp = xmpfile.get_xmp()
+    xmp.set_property(consts.XMP_NS_PDF, 'pdf:Producer', 'Document Converter')
+    xmp.set_property(consts.XMP_NS_XMP, 'xmp:CreatorTool', 'Document Converter')
+    xmp.set_property(consts.XMP_NS_XMP_MM , 'xmpMM:DocumentID', '')
+
+    xmpfile.put_xmp(xmp)
+    xmpfile.close_file()

--- a/docsbox/requirements.txt
+++ b/docsbox/requirements.txt
@@ -18,3 +18,4 @@ PyPDF2==1.26.0
 graypy==0.3.2
 img2pdf==0.3.6
 ocrmypdf==10.2.0
+python-xmp-toolkit==2.0.1


### PR DESCRIPTION
- updated the LibreOffice config
- Added new method to remove metadata. Some of the metadata could not be remove by the xmp lib, like Title, Author and etc. Also using pyPDF2 would remove all metadata including the PDF/A tag. So now the LibreOffice is only for exporting other files to pdf, using pyPDF2 we remove all metadata, then ocrmypdf, that was implemented to convert pdfs, exports to pdf/a and finally we edit the XMP metadata to set the producer of the pdf as 'Document Conversion Service' to remove any indication of how the file is indeed converted.