### PR TITLE
Ghostscript for pdf conversion

### DIFF
--- a/docsbox/config/config.yml
+++ b/docsbox/config/config.yml
@@ -200,7 +200,11 @@ COMMON: &common
     extra:
       system: 'Document Conversion Service'
       environment: 'DEV'
-    
+
+  GHOSTSCRIPT_EXEC: ['gs', '-dPDFA', '-dBATCH', '-dNOPAUSE', '-sProcessColorModel=DeviceRGB', '-sDEVICE=pdfwrite', '-sPDFACompatibilityPolicy=1']
+  OCRMYPDF:
+    EXEC: ['ocrmypdf', '--tesseract-timeout=0', '--optimize=0']
+    FORCE: ['--skip-text', '--force-ocr'] 
 
 DEVELOPMENT: &dev
   <<: *common

--- a/docsbox/docs/tests/test_views.py
+++ b/docsbox/docs/tests/test_views.py
@@ -239,9 +239,9 @@ class DocumentDetectConvertAndRetrieveTestCase(BaseTestCase):
                     self.assertTrue(json.get("taskId"))
                     self.assertEqual(json.get("status"), "queued")
 
-                    ttl = 10
+                    ttl = 50
                     while (ttl > 0):
-                        time.sleep(2)
+                        time.sleep(5)
                         response = self.status_file(json.get("taskId"))
                         json = ujson.loads(response.data)
                         self.assertEqual(response.status_code, 200)

--- a/docsbox/requirements.txt
+++ b/docsbox/requirements.txt
@@ -21,3 +21,5 @@ ocrmypdf==11.3.4
 pikepdf==2.2.0
 python-xmp-toolkit==2.0.1
 Pillow==8.0.0
+piexif==1.1.3
+ghostscript==0.6


### PR DESCRIPTION
Added ghostscript for pdf conversion in response to the issues with some pdfs and ocrmypdf.
Some pdf do not convert properly to pdfa with ghostscript, running ocrmypdf with skip-text option fixes that, also files that were having issues with ocrmypdf after passing with ghostscript no longer have issues.
In some very rare situations, the skip-text still does not set the file to pdfa, so force-ocr is done as a last resort, if the file still is not pdfa then an error is raised indicating that it was not possible to convert the file. 
