### PR TITLE
Image conversion - orientation metadata fix

### DIFF
--- a/docsbox/docs/tasks.py
+++ b/docsbox/docs/tasks.py
@@ -27,7 +27,8 @@ def remove_file(path):
 
 def create_tmp_file_and_get_mimetype(original_file, filename, stream=False, delete=True):
     result = { "mimetype": None, "tmp_file": None }
-    with NamedTemporaryFile(delete=delete, dir=app.config["MEDIA_PATH"]) as tmp_file:
+    suffix = os.path.splitext(filename)[1] if filename else None
+    with NamedTemporaryFile(delete=delete, dir=app.config["MEDIA_PATH"], suffix=suffix) as tmp_file:
         if stream:
             for chunk in original_file.iter_content(chunk_size=128):
                 tmp_file.write(chunk)
@@ -98,7 +99,7 @@ def process_image_convertion(path, options, meta, current_task):
     removeAlpha(path)
     correct_orientation(path)
 
-    with NamedTemporaryFile(dir=app.config["MEDIA_PATH"], delete=False) as tmp_file:
+    with NamedTemporaryFile(dir=app.config["MEDIA_PATH"], delete=False, suffix='.pdf') as tmp_file:
         tmp_file.write(imagesToPdf(path))
         tmp_file.flush()
     remove_file(path)

--- a/docsbox/docs/utils.py
+++ b/docsbox/docs/utils.py
@@ -158,8 +158,8 @@ def removeAlpha(image_path):
 def correct_orientation(image_path):
     with PIL_Image.open(image_path) as image:
         exif = image._getexif()
-        exif_dict = piexif.load(image_path)
         if exif:
+            exif_dict = piexif.load(image_path)
             for tag, value in exif.items():
                 if ExifTags.TAGS.get(tag, tag) == "Orientation":
                     if value == 0:
@@ -169,6 +169,6 @@ def correct_orientation(image_path):
                     elif value in (5, 7):
                         exif_dict["0th"][piexif.ImageIFD.Orientation] = value + 1
 
-        exif_bytes = piexif.dump(exif_dict)
-        image.save(image_path, image.format, exif=exif_bytes)
+            exif_bytes = piexif.dump(exif_dict)
+            image.save(image_path, image.format, exif=exif_bytes)
                 

--- a/docsbox/docs/utils.py
+++ b/docsbox/docs/utils.py
@@ -153,30 +153,22 @@ def removeAlpha(image_path):
             bg = PIL_Image.new("RGB", image.size, (255,255,255,255))
             bg.paste(image, mask=alpha)
             bg.convert('RGB')
-            bg.save(image_path, 'JPEG')
+            bg.save(image_path, image.format)
 
 def correct_orientation(image_path):
     with PIL_Image.open(image_path) as image:
-        try:
-            for orientation in ExifTags.TAGS.keys():
-                if ExifTags.TAGS[orientation]=='Orientation':
-                    break
-            
-            exif = image._getexif()
-            if exif:
-                if exif[orientation] == 3:
-                    image = image.rotate(180, expand=True)
-                elif exif[orientation] == 6:
-                    image = image.rotate(270, expand=True)
-                elif exif[orientation] == 8:
-                    image = image.rotate(90, expand=True)
-                else:
-                    exif_dict = piexif.load(image.info['exif'])
-                    exif_dict['orientation'] = 1
-                    exif_bytes = piexif.dump(exif_dict)
-                    image.save(image_path, None, exif=exif_bytes)
-            else:
-                return
-        except (AttributeError, KeyError, IndexError):
-            # cases: image don't have getexif
-            pass
+        exif = image._getexif()
+        exif_dict = piexif.load(image_path)
+        if exif:
+            for tag, value in exif.items():
+                if ExifTags.TAGS.get(tag, tag) == "Orientation":
+                    if value == 0:
+                        exif_dict["0th"][piexif.ImageIFD.Orientation] = 1
+                    elif value in (2, 4):
+                        exif_dict["0th"][piexif.ImageIFD.Orientation] = value - 1
+                    elif value in (5, 7):
+                        exif_dict["0th"][piexif.ImageIFD.Orientation] = value + 1
+
+        exif_bytes = piexif.dump(exif_dict)
+        image.save(image_path, image.format, exif=exif_bytes)
+                

--- a/docsbox/docs/views.py
+++ b/docsbox/docs/views.py
@@ -95,13 +95,13 @@ class DocumentConvertView(Resource):
         result = {}
         try:
             if request.files and "file" in request.files:
-                filename = remove_extension(request.files["file"].filename)
+                filename = request.files["file"].filename
                 result = create_tmp_file_and_get_mimetype(request.files["file"], filename, delete=False)
                 via_allowed_users = None
             elif file_id and is_valid_uuid(file_id):
                 r = get_file_from_via(file_id)
                 if r.status_code == 200:
-                    filename = remove_extension(request.headers['Content-Disposition'])
+                    filename = request.headers['Content-Disposition']
                     result = create_tmp_file_and_get_mimetype(r, filename, stream=True, delete=False)
 
                     if 'Via-Allowed-Users' in request.headers:
@@ -129,7 +129,7 @@ class DocumentConvertView(Resource):
                 options = set_options(request.form.get("options", None), mimetype)
 
                 task = process_convertion.queue(tmp_file.name, options, 
-                                                { "filename": filename, "mimetype": mimetype, 
+                                                { "filename": remove_extension(filename), "mimetype": mimetype, 
                                                 "via_allowed_users": via_allowed_users })
                 response = { "taskId": task.id, "status": task.get_status() }
 

--- a/docsbox/requirements.txt
+++ b/docsbox/requirements.txt
@@ -1,5 +1,5 @@
 redis==3.5.3
-rq==1.7.0
+rq==1.8.0
 Flask==1.1.2
 Flask-RESTful==0.3.8
 Flask-RQ2==18.3
@@ -9,17 +9,17 @@ pylokit==0.8.1
 filemagic==1.6
 cffi==1.14.4
 wand==0.6.3
-ujson==4.0.1
+ujson==4.0.2
 nose==1.3.7
 nose-watch==0.9.2
-coverage==5.3
+coverage==5.5
 ordbok==0.1.9
 PyPDF3==1.0.1
 graypy==2.1.0
 img2pdf==0.3.6 # >=0.4.0 will cause issues
-ocrmypdf==11.3.4
-pikepdf==2.2.0
+ocrmypdf==11.7.3
+pikepdf==2.11.1
 python-xmp-toolkit==2.0.1
-Pillow==8.0.0
+Pillow==8.2.0
 piexif==1.1.3
-ghostscript==0.6
+ghostscript==0.7


### PR DESCRIPTION
- re-added extension for temp files since Pillow library needed file format to open, it had been previously removed because of an issue with files with space and dot. The solution works for both situations.
- Updated correct_orientation method since the issue was that scanned files have exif.Orientation=0 and the correct code for no rotation is exif.Orientation=1