### PR TITLE
Image compression and xmp parsing error fix

### DIFF
--- a/docsbox/config/config.yml
+++ b/docsbox/config/config.yml
@@ -201,9 +201,9 @@ COMMON: &common
       system: 'Document Conversion Service'
       environment: 'DEV'
 
-  GHOSTSCRIPT_EXEC: ['gs', '-dPDFA', '-dBATCH', '-dNOPAUSE', '-sProcessColorModel=DeviceRGB', '-sDEVICE=pdfwrite', '-sPDFACompatibilityPolicy=1']
+  GHOSTSCRIPT_EXEC: ['gs', '-dPDFA', '-dBATCH', '-dNOPAUSE', '-sProcessColorModel=DeviceRGB', '-sDEVICE=pdfwrite', '-sPDFACompatibilityPolicy=1', '-dPDFSETTINGS=/printer']
   OCRMYPDF:
-    EXEC: ['ocrmypdf', '--tesseract-timeout=0', '--optimize=0']
+    EXEC: ['ocrmypdf', '--tesseract-timeout=0', '--optimize=1']
     FORCE: ['--skip-text', '--force-ocr'] 
 
 DEVELOPMENT: &dev

--- a/docsbox/docs/utils.py
+++ b/docsbox/docs/utils.py
@@ -137,14 +137,17 @@ def remove_XMPMeta(file):
     xmpfile.close_file()
 
 def has_PDFA_XMP(file):
-    with open(file, mode="rb") as fileData:
-        xmpfile = PdfFileReader(fileData, strict=False)
-        metadata = xmpfile.getXmpMetadata()
-        if metadata is not None:
-            pdfa=app.config["PDFA"]
-            nodes = metadata.getNodesInNamespace("", pdfa["NAMESPACE"])
-            if get_pdfa_version(nodes) in pdfa["ACCEPTED_VERSIONS"]:
-                return True
+    try:
+        with open(file, mode="rb") as fileData:
+            xmpfile = PdfFileReader(fileData, strict=False)
+            metadata = xmpfile.getXmpMetadata()
+            if metadata is not None:
+                pdfa=app.config["PDFA"]
+                nodes = metadata.getNodesInNamespace("", pdfa["NAMESPACE"])
+                if get_pdfa_version(nodes) in pdfa["ACCEPTED_VERSIONS"]:
+                    return True
+            return False
+    except:
         return False
 
 def removeAlpha(image_path):

--- a/docsbox/requirements.txt
+++ b/docsbox/requirements.txt
@@ -14,10 +14,10 @@ nose==1.3.7
 nose-watch==0.9.2
 coverage==5.5
 ordbok==0.1.9
-PyPDF3==1.0.3
+PyPDF3==1.0.4
 graypy==2.1.0
 img2pdf==0.3.6 # >=0.4.0 will cause issues
-ocrmypdf==12.0.1
+ocrmypdf==12.0.3
 pikepdf==2.12.0
 python-xmp-toolkit==2.0.1
 Pillow==8.2.0


### PR DESCRIPTION
- Image compression for ghostscript, and optimization for ocr
- 'Try catch' for parsing error on getXmpMetadata