### PR TITLE
SSY-49 improvements

### DIFF
--- a/docsbox/config/config.yml
+++ b/docsbox/config/config.yml
@@ -12,6 +12,7 @@ COMMON: &common
   VIA_URL: https://it1.integraatiopalvelu.fi/Tallennuspalvelu
   VIA_CERT_PATH: /home/docsbox/certificate.pem
   VIA_ALLOWED_USERS: 
+  VIA_RETRY_MAX: 5
 
   THUMBNAILS_GENERATE: False
   THUMBNAILS_DPI": 90

--- a/docsbox/config/gunicorn.conf
+++ b/docsbox/config/gunicorn.conf
@@ -2,5 +2,7 @@ bind = '0.0.0.0:8000'
 
 capture_output = True
 
+threads = 8
+
 access_log_format = '%(h)s %(u)s [%(m)s] "%(U)s" [%(s)s]'
 logconfig = "docsbox/config/logging.conf"

--- a/docsbox/docs/tasks.py
+++ b/docsbox/docs/tasks.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 import traceback
-import logging
 
 from subprocess import run
 from wand.image import Image
@@ -45,19 +44,18 @@ def process_convertion(path, options, meta):
         current_task = get_current_job()
         exportFormatType = app.config["CONVERTABLE_MIMETYPES"][meta["mimetype"]]["formats"]
         if exportFormatType in app.config["DOCUMENT_CONVERTION_FORMATS"]:
-            result= process_document_convertion(path, options, meta, current_task)
+            result = process_document_convertion(path, options, meta, current_task)
         elif exportFormatType == "IMAGE_EXPORT_FORMATS":
-            result= process_image_convertion(path, options, meta, current_task)
+            result = process_image_convertion(path, options, meta, current_task)
         else:
             return { "has_failed": True, "message": "Conversion for {0} is not supported".format(exportFormatType)}
         if result and options["via_allowed_users"]:
             r = save_file_on_via(app.config["MEDIA_PATH"] + current_task.id, result["mimeType"], options["via_allowed_users"])
             remove_file(app.config["MEDIA_PATH"] + current_task.id)
             result['fileId'] = r.headers.get("Document-id")
-        app.logger.log(logging.INFO, str(result))
         return result
     except Exception as e:
-        return { "has_failed": True, "message": e , "traceback": traceback.format_exc() }
+        return { "has_failed": True, "message": str(e), "traceback": traceback.format_exc() }
 
 def process_document_convertion(path, options, meta, current_task):
     output_path = os.path.join(app.config["MEDIA_PATH"], current_task.id)

--- a/docsbox/docs/via_controller.py
+++ b/docsbox/docs/via_controller.py
@@ -1,3 +1,6 @@
+import logging
+import time
+
 from requests import get, post
 from docsbox import app
 
@@ -5,11 +8,25 @@ from docsbox import app
 def get_file_from_via(file_id):
     url = app.config["VIA_URL"] + "/" + file_id
     cert = app.config["VIA_CERT_PATH"]
-    return get(url=url, cert=cert, stream=True, timeout=60)
+    return retry(lambda: get(url=url, cert=cert, stream=True, timeout=60))
 
 def save_file_on_via(file_path, mime_type, via_allowed_users):
     with open(file_path, "rb") as data:
         cert = app.config["VIA_CERT_PATH"]
         headers = { 'VIA_ALLOWED_USERS': via_allowed_users, 'Content-type': mime_type }
-        response = post(url=app.config["VIA_URL"], cert=cert, data=data, headers=headers, timeout=60)
+        response = retry(lambda: post(url=app.config["VIA_URL"], cert=cert, data=data, headers=headers, stream=True, timeout=60))
     return response
+
+def retry(call, max = int(app.config["VIA_RETRY_MAX"]), count = 0):
+    try:
+        response = call()
+        if count > 1:
+            logging.warn('Retry successful on count ' + str(count))
+        return response
+    except Exception as e:
+        if count >= max:
+            logging.warn('Maximum retry count exceeded, rethrowing...')
+            raise e
+        logging.warn('Error in VIA call, retrying... : ' + str(e))
+        time.sleep(1)
+        return retry(call, max, count + 1)

--- a/docsbox/logs/__init__.py
+++ b/docsbox/logs/__init__.py
@@ -1,11 +1,8 @@
 import logging
 import ssl
-import socket
-import sys
 
 from http.client import HTTPSConnection
 from graypy.handler import BaseGELFHandler
-from flask.logging import default_handler
 
 
 class GraylogLogger(logging.LoggerAdapter):


### PR DESCRIPTION
* Use threads in gunicorn to enable concurrency in flask requests
* Fix error handling for when an error happens in the VIA upload request the logs would only display "Unserializable return value"
* Add a retry functionality for VIA requests, retry a maximum of 5 times on a 1 second interval on errors