### PR TITLE
SSY-5323 fix integer out of bounds in exif metadata

### DIFF
--- a/docsbox/docs/tasks.py
+++ b/docsbox/docs/tasks.py
@@ -130,7 +130,7 @@ def process_image_convertion(input_path, options, meta, current_task):
         input_path = tmp_path
 
     remove_alpha(input_path)
-    correct_orientation(input_path)
+    sanitize_metadata(input_path)
 
     with NamedTemporaryFile(dir=app.config["MEDIA_PATH"], delete=False, suffix='.pdf') as tmp_file:
         tmp_file.write(images_to_pdf(input_path))

--- a/docsbox/logs/__init__.py
+++ b/docsbox/logs/__init__.py
@@ -27,7 +27,10 @@ class GraylogLogger(logging.LoggerAdapter):
                 kwargs["extra"]["request"]= '%s - "%s"' % (request.method, request.path)
             if extra and isinstance(extra, dict):
                 kwargs["extra"].update(extra)
-            self.logger.log(level, msg, *args, **kwargs)
+            if level >= logging.ERROR:
+                self.logger.error(level, msg, *args, **kwargs)
+            else:
+                self.logger.log(level, msg, *args, **kwargs)
 
 
 class GelfHTTPHandler(BaseGELFHandler, logging.Handler):


### PR DESCRIPTION
* Some files might contain metadata that in the exif definition are assigned a signed int type, but they are embedded in the file as unsigned causing an error because it exceeds the max signed int value. Added implementation to convert unsigned Rational and -Long types to signed int if they exceed the signed bounds