### PR TITLE
SSY-5186 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If it is not provided, the service will scan the file.
 | convertable | `boolean` whether or not the service is able to convert the file. Will also be false if the file is already in PDF/A format                                                 |
 | fileType    | `string` a human-readable representation of the file's mimetype. Will be returned only if the file is convertable by the service, otherwise will return "Unknown/Corrupted" | 
 | mimeType    | `string` the file's mimetype                                                                                                                                                |
-| pdfVersion  | `string` PDF version, if the mimetype is `application/pdf`, otherwise empty. Will only be returned if the service scanned the file, meaning that                            |
+| pdfVersion  | `string` PDF version, if the mimetype is `application/pdf`, otherwise empty. Will only be returned if the service scanned the file.                                         |
 
 ### Status codes
 | Status | Description                                            |
@@ -134,7 +134,7 @@ Queued
 | status     | `string` the status of the conversion, can be `queued`, `started`, `finished`, `failed`, `corrupted`, `non-convertable`                                                     |
 | fileType   | `string` a human-readable representation of the file's mimetype. Will be returned only if the file is convertable by the service, otherwise will return "Unknown/Corrupted" | 
 | mimeType   | `string` the file's mimetype                                                                                                                                                |
-| pdfVersion | `string` PDF version, if the mimetype is `application/pdf`, otherwise empty. Will only be returned if the service scanned the file, meaning that                            |
+| pdfVersion | `string` PDF version, if the mimetype is `application/pdf`, otherwise empty. Will only be returned if the service scanned the file.                                         |
 
 
 ### Status codes

--- a/docsbox/docs/views.py
+++ b/docsbox/docs/views.py
@@ -78,10 +78,10 @@ class DocumentTypeView(Resource):
             else:
                 return abort(400, "No file was sent nor valid file id given", request)
 
-            response["convertable"] = mimetype in app.config["CONVERTABLE_MIMETYPES"]
+            is_pdfa = mimetype == "application/pdf" and version
+            response["convertable"] = not is_pdfa and mimetype in app.config["CONVERTABLE_MIMETYPES"]
             response["mimeType"] = mimetype
             response["pdfVersion"] = version
-            is_pdfa = mimetype == "application/pdf" and version
             if is_pdfa:
                 response["fileType"] = "PDF/A"
             elif response["convertable"]:


### PR DESCRIPTION
* Return convertable false for PDF/A because Ulsa & Sampo and others depend on it being false in this situation even though the service supports converting it to different formats