### PR TITLE
SSY-7731 Fix issue where some of files are converted as empty conversions

### DIFF
--- a/docsbox/config/config.yml
+++ b/docsbox/config/config.yml
@@ -229,5 +229,5 @@ LOGGING_ENVIRONMENT: 'DEV'
 
 GHOSTSCRIPT_EXEC: ['gs', '-dPDFA=$pdfVersion', '-dBATCH', '-dNOPAUSE', '-sColorConversionStrategy=RGB', '-sProcessColorModel=DeviceRGB', '-sDEVICE=pdfwrite', '-dPDFACompatibilityPolicy=1', '-dPDFSETTINGS=/printer', '-dNumRenderingThreads=8', '-dMaxPatternBitmap=2000000', '-dBufferSpace=2000000000', '-sOutputFile=$outputFile', '-c "100000000 setvmthreshold" -f', '$inputFile']
 OCRMYPDF:
-  EXEC: ['ocrmypdf', '--tesseract-timeout=0', '--optimize=0', '--output-type=pdfa-$pdfVersion']
+  EXEC: ['ocrmypdf', '--tesseract-timeout=0', '--optimize=0', '--output-type=pdfa-$pdfVersion', '--skip-big=500']
   FORCE: ['--skip-text', '--force-ocr']


### PR DESCRIPTION
if images inside are more than 500mb skip them instead of giving error because it could be decompression bomb DOS attack