### PR TITLE
SSY-8020 Remove setvmthreshold command line option

### DIFF
--- a/docsbox/config/config.yml
+++ b/docsbox/config/config.yml
@@ -229,7 +229,7 @@ LOGGING:
     system: 'Document Conversion Service'
     environment: 'DEV'
 
-GHOSTSCRIPT_EXEC: ['gs', '-dPDFA=$pdfVersion', '-dBATCH', '-dNOPAUSE', '-sColorConversionStrategy=RGB', '-sProcessColorModel=DeviceRGB', '-sDEVICE=pdfwrite', '-dPDFACompatibilityPolicy=1', '-dPDFSETTINGS=/printer', '-dNumRenderingThreads=8', '-dMaxPatternBitmap=2000000', '-dBufferSpace=2000000000', '-sOutputFile=$outputFile', '-c "100000000 setvmthreshold" -f', '$inputFile']
+GHOSTSCRIPT_EXEC: ['gs', '-dPDFA=$pdfVersion', '-dBATCH', '-dNOPAUSE', '-sColorConversionStrategy=RGB', '-sProcessColorModel=DeviceRGB', '-sDEVICE=pdfwrite', '-dPDFACompatibilityPolicy=1', '-dPDFSETTINGS=/printer', '-dNumRenderingThreads=8', '-dMaxPatternBitmap=2000000', '-dBufferSpace=2000000000', '-sOutputFile=$outputFile', '$inputFile']
 OCRMYPDF:
   EXEC: ['ocrmypdf', '--tesseract-timeout=0', '--optimize=0', '--output-type=pdfa-$pdfVersion', '--skip-big=500', '--invalidate-digital-signatures']
   FORCE: ['--skip-text', '--force-ocr']


### PR DESCRIPTION
Option setvmthreshold  somehow doesn't like images, though the idea of this option is just to increase vm memory for more process power removing seems to fix the fact some files are converted into a blank pdf.

Also should we put this on a 24.1.1 hotfix version?