### PR TITLE
SSY-8712 transfer header keys to lower case before checking them

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ If it is not provided, the service will scan the file.
     }
 
 ### Types
-| Type        | Description                                                                                                                                                                 |
-|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| convertable | `boolean` whether or not the service is able to convert the file. Will also be false if the file is already in PDF/A format                                                 |
-| fileType    | `string` a human-readable representation of the file's mimetype. Will be returned only if the file is convertable by the service, otherwise will return "Unknown/Corrupted" | 
-| mimeType    | `string` the file's mimetype                                                                                                                                                |
-| pdfVersion  | `string` PDF version, if the mimetype is `application/pdf`, otherwise empty. Will only be returned if the service scanned the file.                                         |
+| Type        | Description                                                                                                                                                                                                                                                                                          |
+|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| convertable | `boolean` whether or not the service is able to convert the file. Will also be false if the file is already in PDF/A format                                                                                                                                                                          |
+| fileType    | `string` a human-readable representation of the file's mimetype. Will be returned only if the file is convertable by the service, otherwise will return "Unknown/Corrupted". If the file is a PDF and is password protected, will return one of 'password-protected-partial' or 'password-protected' | 
+| mimeType    | `string` the file's mimetype                                                                                                                                                                                                                                                                         |
+| pdfVersion  | `string` PDF version, if the mimetype is `application/pdf`, otherwise empty. Will only be returned if the service scanned the file.                                                                                                                                                                  |
 
 ### Status codes
 | Status | Description                                            |
@@ -128,13 +128,13 @@ Queued
     }
 
 ### Types
-| Type       | Description                                                                                                                                                                 |
-|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| taskId     | `string` UUID specific for this task, use this when polling the status of the conversion                                                                                    |
-| status     | `string` the status of the conversion, can be `queued`, `started`, `finished`, `failed`, `corrupted`, `non-convertable`                                                     |
-| fileType   | `string` a human-readable representation of the file's mimetype. Will be returned only if the file is convertable by the service, otherwise will return "Unknown/Corrupted" | 
-| mimeType   | `string` the file's mimetype                                                                                                                                                |
-| pdfVersion | `string` PDF version, if the mimetype is `application/pdf`, otherwise empty. Will only be returned if the service scanned the file.                                         |
+| Type       | Description                                                                                                                                                                                                                                                                                          |
+|------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| taskId     | `string` UUID specific for this task, use this when polling the status of the conversion                                                                                                                                                                                                             |
+| status     | `string` the status of the conversion, can be `queued`, `started`, `finished`, `failed`, `corrupted`, `non-convertable`                                                                                                                                                                              |
+| fileType   | `string` a human-readable representation of the file's mimetype. Will be returned only if the file is convertable by the service, otherwise will return "Unknown/Corrupted". If the file is a PDF and is password protected, will return one of 'password-protected-partial' or 'password-protected' | 
+| mimeType   | `string` the file's mimetype                                                                                                                                                                                                                                                                         |
+| pdfVersion | `string` PDF version, if the mimetype is `application/pdf`, otherwise empty. Will only be returned if the service scanned the file.                                                                                                                                                                  |
 
 
 ### Status codes
@@ -170,18 +170,18 @@ If the file was sent directly to the conversion service, the converted file is s
     Body: file bytes
 
 ### Types
-| Type        | Description                                                                                                                                                                 |
-|-------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| convertable | `boolean` always `true`                                                                                                                                                     |
-| fileType    | `string` a human-readable representation of the file's mimetype. Will be returned only if the file is convertable by the service, otherwise will return "Unknown/Corrupted" | 
-| mimeType    | `string` the file's mimetype                                                                                                                                                |
-| pdfVersion  | `string` PDF version, if the mimetype is `application/pdf`, otherwise empty. Will only be returned if the service scanned the file, meaning that                            |
-| fileId      | `string` the file if with which the converted file can be downloaded with from VIA                                                                                          |
-| taskId      | `string` UUID specific for this task, use this when polling the status of the conversion                                                                                    |
-| fileName    | `string` the file name                                                                                                                                                      |
-| pdfVersion  | `string` the PDF version of the converted file, if it was converted into a PDF                                                                                              |
-| fileSize    | `number` the file size in bytes                                                                                                                                             |
-| status      | `string` always `finished`                                                                                                                                                  |
+| Type        | Description                                                                                                                                                                                                                                                                                          |
+|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| convertable | `boolean` always `true`                                                                                                                                                                                                                                                                              |
+| fileType    | `string` a human-readable representation of the file's mimetype. Will be returned only if the file is convertable by the service, otherwise will return "Unknown/Corrupted". If the file is a PDF and is password protected, will return one of 'password-protected-partial' or 'password-protected' | 
+| mimeType    | `string` the file's mimetype                                                                                                                                                                                                                                                                         |
+| pdfVersion  | `string` PDF version, if the mimetype is `application/pdf`, otherwise empty. Will only be returned if the service scanned the file, meaning that                                                                                                                                                     |
+| fileId      | `string` the file if with which the converted file can be downloaded with from VIA                                                                                                                                                                                                                   |
+| taskId      | `string` UUID specific for this task, use this when polling the status of the conversion                                                                                                                                                                                                             |
+| fileName    | `string` the file name                                                                                                                                                                                                                                                                               |
+| pdfVersion  | `string` the PDF version of the converted file, if it was converted into a PDF                                                                                                                                                                                                                       |
+| fileSize    | `number` the file size in bytes                                                                                                                                                                                                                                                                      |
+| status      | `string` always `finished`                                                                                                                                                                                                                                                                           |
 
 ### Status codes
 | Status | Description                                  |

--- a/docsbox/docs/tasks.py
+++ b/docsbox/docs/tasks.py
@@ -39,6 +39,8 @@ def process_convertion_by_id(file_id, headers):
             version = ""
             if via_response.status_code == 200:
                 file_path = store_file(via_response, filename, stream=True)
+                if mimetype is None:
+                    mimetype = via_response.headers.get('Content-Type')
                 if mimetype is None or mimetype == "application/pdf" or mimetype not in app.config["CONVERTABLE_MIMETYPES"]:
                     mimetype, version = get_file_mimetype(file_path)
             else:
@@ -54,7 +56,6 @@ def process_convertion_by_id(file_id, headers):
 
         options = set_options(headers, file_info["mimetype"])
         output_pdf_version = options.get("output_pdf_version", "1")
-        is_pdfa = file_info["mimetype"] == "application/pdf" and file_info["pdf_version"]
         req_same_version = file_info["mimetype"] == "application/pdf" and file_info["pdf_version"] and file_info["pdf_version"][0] == output_pdf_version
         if file_info["mimetype"] not in app.config["CONVERTABLE_MIMETYPES"]:
             return {

--- a/docsbox/docs/utils.py
+++ b/docsbox/docs/utils.py
@@ -50,6 +50,9 @@ def set_options(headers, mimetype):
     else:
         options = app.config["PDF_DEFAULT_OPTIONS"]
     if headers:
+        # Lower case keys for header names
+        headers = {k.lower(): v for k, v in headers.items()}
+
         if 'conversion-format' in headers:
             conversion_format = headers["conversion-format"]
             if mimetype in app.config["CONVERTABLE_MIMETYPES"] and conversion_format in app.config[app.config["CONVERTABLE_MIMETYPES"][mimetype]["formats"]]:
@@ -63,10 +66,10 @@ def set_options(headers, mimetype):
             if output_pdf_version in ["1", "2", "3"]:
                 options["output_pdf_version"] = output_pdf_version
             else:
-                raise ValueError("Invalid 'output_pdf_version' value")
+                raise ValueError("Invalid 'output_pdf_version' value. Allowed are 1, 2 and 3")
 
-        if 'Via-Allowed-Users' in headers:
-            options["via_allowed_users"] = headers['Via-Allowed-Users']
+        if 'via-allowed-users' in headers:
+            options["via_allowed_users"] = headers['via-allowed-users']
         else:
             options["via_allowed_users"] = app.config["VIA_ALLOWED_USERS"]
 

--- a/docsbox/docs/utils.py
+++ b/docsbox/docs/utils.py
@@ -13,7 +13,7 @@ from piexif import InvalidImageDataError
 from requests import exceptions
 from xml.parsers.expat import ExpatError
 from pypdf import PdfReader
-from pypdf.errors import PyPdfError
+from pypdf.errors import PyPdfError, PdfReadError
 from libxmp import XMPFiles, consts
 from wand.image import Image
 from PIL import Image as PIL_Image
@@ -128,7 +128,8 @@ def store_file_from_id(file_id, filename):
     try:
         via_response = get_file_from_via(file_id)
         if via_response.status_code == 200:
-            return store_file(via_response, filename, True)
+            mimetype = via_response.headers.get('Content-Type')
+            return store_file(via_response, filename, True), mimetype
         elif via_response.status_code == 404:
             raise VIAException(404, "File id was not found.")
         else:
@@ -148,23 +149,6 @@ def store_file(data, filename, stream=False):
     return tmp_file.name
 
 
-def get_file_mimetype_from_id(file_id, filename=None):
-    try:
-        via_response = get_file_from_via(file_id)
-        if via_response.status_code == 200:
-            mimetype = via_response.headers.get('Content-Type')
-            version = ""
-            if mimetype is None or mimetype == "application/pdf" or mimetype not in app.config["CONVERTABLE_MIMETYPES"]:
-                mimetype, version = get_file_mimetype_from_data(via_response, filename, stream=True)
-            return mimetype, version
-        elif via_response.status_code == 404:
-            raise VIAException(404, "File id was not found.")
-        else:
-            raise VIAException(via_response.status_code, via_response)
-    except exceptions.Timeout:
-        raise VIAException(504, "VIA service took too long to respond.")
-
-
 def get_file_mimetype_from_data(data, filename, stream=False):
     suffix = os.path.splitext(filename)[1] if filename else ""
     with NamedTemporaryFile(suffix=suffix) as tmp_file:
@@ -178,25 +162,32 @@ def get_file_mimetype_from_data(data, filename, stream=False):
     return mimetype, version
 
 
-def get_file_mimetype(file):
+def get_file_mimetype(file, req_mimetype=None):
     version = ""
-    try:
-        mime_type_file = exiftool.ExifToolHelper().get_metadata(file)[0]["File:MIMEType"]
-        if mime_type_file == "application/pdf":
-            version = read_pdf_version(file)
+    if req_mimetype is None or req_mimetype == "application/pdf" or req_mimetype not in app.config["CONVERTABLE_MIMETYPES"]:
+        try:
+            mime_type_file = exiftool.ExifToolHelper().get_metadata(file)[0]["File:MIMEType"]
+            if mime_type_file == "application/pdf":
+                protection_status = pdf_protection_status(file)
+                if protection_status:
+                    mime_type_file = protection_status
+                    return mime_type_file, version
+                version = read_pdf_version(file)
 
-        elif mime_type_file in app.config["GENERIC_MIMETYPES"]:
-            mime_type_file = magic.from_file(file, mime=True)
-            if mime_type_file in app.config["GENERIC_MIMETYPES"]:
-                with open(file, mode="rb") as file_data:
-                    document_type_file = magic.from_buffer(file_data.read(2048))
-                    for file_mimetype, file_format in itertools.zip_longest(
-                            app.config["FILEMIMETYPES"],
-                            app.config["FILEFORMATS"]):
-                        if document_type_file in file_format:
-                            mime_type_file = file_mimetype
-    except (ValueError, PyPdfError):
-        mime_type_file = "Unknown/Corrupted"
+            elif mime_type_file in app.config["GENERIC_MIMETYPES"]:
+                mime_type_file = magic.from_file(file, mime=True)
+                if mime_type_file in app.config["GENERIC_MIMETYPES"]:
+                    with open(file, mode="rb") as file_data:
+                        document_type_file = magic.from_buffer(file_data.read(2048))
+                        for file_mimetype, file_format in itertools.zip_longest(
+                                app.config["FILEMIMETYPES"],
+                                app.config["FILEFORMATS"]):
+                            if document_type_file in file_format:
+                                mime_type_file = file_mimetype
+        except (ValueError, PyPdfError):
+            mime_type_file = "Unknown/Corrupted"
+    else:
+        mime_type_file = req_mimetype
     return mime_type_file, version
 
 
@@ -216,6 +207,24 @@ def read_pdf_version(file):
                 "File {0} has not well-formed XMP data, could not verify if application/pdf has PDF/A DOCINFO.".format(file))
 
     return version
+
+
+def pdf_protection_status(path):
+    try:
+        reader = PdfReader(path, strict=False)
+    except (PdfReadError, OSError):
+        return None
+
+    if reader.is_encrypted:
+        # Try the owner-password shortcut – empty string.
+        # decrypt() returns:
+        #   1 → user password accepted
+        #   2 → owner password accepted
+        #   0 → password wrong
+        if reader.decrypt("") in (1, 2):
+            return "password-protected-partial"
+        return "password-protected"
+    return None
 
 
 def remove_extension(file):

--- a/docsbox/docs/views.py
+++ b/docsbox/docs/views.py
@@ -7,8 +7,7 @@ from flask import request, send_from_directory, jsonify
 from flask_restful import Resource
 from docsbox import app, db
 from docsbox.docs.tasks import get_task, process_convertion, process_convertion_by_id, remove_file
-from docsbox.docs.utils import get_file_mimetype_from_data, is_valid_uuid, store_file, get_file_mimetype, set_options, \
-    store_file_from_id, get_file_mimetype_from_id
+from docsbox.docs.utils import get_file_mimetype_from_data, is_valid_uuid, store_file, get_file_mimetype, set_options, store_file_from_id
 from docsbox.docs.via_controller import VIAException
 
 
@@ -86,6 +85,9 @@ class DocumentTypeView(Resource):
                 response["fileType"] = "PDF/A"
             elif response["convertable"]:
                 response["fileType"] = app.config["CONVERTABLE_MIMETYPES"][mimetype]["name"]
+            elif mimetype == "password-protected-partial" or mimetype == "password-protected":
+                response["fileType"] = mimetype
+                response["message"] = "The file is password protected"
             else:
                 response["fileType"] = "Unknown/Corrupted"
                 response["message"] = "The file type is not supported or the file is corrupted"
@@ -112,7 +114,7 @@ class DocumentConvertView(Resource):
                 mimetype, version = get_file_mimetype(file_path)
                 save_in_via = False
             elif file_id and is_valid_uuid(file_id):
-                file_info = get_file_info(file_id, request.headers.get('Content-Disposition'), save_file=True)
+                file_info = get_file_info(file_id, request.headers.get('Content-Disposition'))
                 filename = file_info["filename"]
                 mimetype = file_info["mimetype"]
                 file_path = file_info["file_path"]
@@ -243,14 +245,11 @@ class DocumentDownloadView(Resource):
         return response
 
 
-def get_file_info(file_id, filename="", save_file=False):
+def get_file_info(file_id, filename=""):
     if db.exists('fileId:' + file_id) == 0:
         file_info = {"file_id": file_id, "mimetype": "", "filename": filename, "datetime": datetime.now().strftime('%Y/%m/%d-%H:%M:%S')}
-        if save_file:
-            file_info["file_path"] = store_file_from_id(file_id, filename)
-            file_info["mimetype"], file_info["pdf_version"] = get_file_mimetype(file_info["file_path"])
-        else:
-            file_info["mimetype"], file_info["pdf_version"] = get_file_mimetype_from_id(file_id, filename)
+        file_info["file_path"], file_info["mimetype"] = store_file_from_id(file_id, filename)
+        file_info["mimetype"], file_info["pdf_version"] = get_file_mimetype(file_info["file_path"], file_info["mimetype"])
         db.set('fileId:' + file_id, json.dumps(file_info))
     else:
         file_info = json.loads(db.get('fileId:' + file_id))
@@ -260,8 +259,8 @@ def get_file_info(file_id, filename="", save_file=False):
            file_info["filename"] = filename
            updated = True
 
-        if save_file and "file_path" not in file_info:
-            file_info["file_path"] = store_file_from_id(file_id, filename)
+        if "file_path" not in file_info:
+            file_info["file_path"], file_info["mimetype"] = store_file_from_id(file_id, filename)
             updated = True
 
         if updated:


### PR DESCRIPTION
- Fixes request headers not working
- Adds new error codes when reading the file type of PDF files for password protected files
- Always saves the file when it has been downloaded from VIA because the next request after get-file-type most likely is convert and the file would otherwise be downloaded again